### PR TITLE
Add arXiv metadata dump loader

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,6 +13,6 @@ repos:
       - id: eslint
         files: "\\.(ts|tsx)$"
   - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v3.3.2
+    rev: v3.1.0
     hooks:
       - id: prettier

--- a/backend/app/arxiv_loader.py
+++ b/backend/app/arxiv_loader.py
@@ -1,0 +1,40 @@
+import argparse
+import json
+import tarfile
+from typing import Iterator, Dict, Any
+
+
+def iter_arxiv_records(tar_path: str) -> Iterator[Dict[str, Any]]:
+    """Yield records from a compressed arXiv metadata dump.
+
+    The dump is expected to be a tar.xz archive containing a single
+    ``arXiv-metadata-oai-snapshot.json`` file with one JSON object per
+    line. Records are yielded lazily so the file can be processed
+    without loading everything into memory.
+    """
+    with tarfile.open(tar_path, mode="r:xz") as tar:
+        member = tar.extractfile("arXiv-metadata-oai-snapshot.json")
+        if member is None:
+            raise FileNotFoundError(
+                "arXiv-metadata-oai-snapshot.json not found in archive"
+            )
+        for line in member:
+            yield json.loads(line)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Iterate arXiv metadata dump")
+    parser.add_argument("tar_path", help="Path to arXiv-metadata-dump tar.xz file")
+    parser.add_argument(
+        "--limit", type=int, default=5, help="Number of records to print"
+    )
+    args = parser.parse_args()
+
+    for idx, record in enumerate(iter_arxiv_records(args.tar_path)):
+        print(record.get("id"), record.get("title"))
+        if idx + 1 >= args.limit:
+            break
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/tests/test_arxiv_loader.py
+++ b/backend/tests/test_arxiv_loader.py
@@ -1,0 +1,25 @@
+import json
+import tarfile
+from pathlib import Path
+
+from app.arxiv_loader import iter_arxiv_records
+
+
+def create_sample_dump(tmp_path: Path):
+    data = [
+        {"id": "1", "title": "First"},
+        {"id": "2", "title": "Second"},
+    ]
+    json_content = "\n".join(json.dumps(r) for r in data).encode()
+    json_file = tmp_path / "arXiv-metadata-oai-snapshot.json"
+    json_file.write_bytes(json_content)
+    tar_path = tmp_path / "sample.tar.xz"
+    with tarfile.open(tar_path, "w:xz") as tar:
+        tar.add(json_file, arcname="arXiv-metadata-oai-snapshot.json")
+    return tar_path, data
+
+
+def test_iter_arxiv_records(tmp_path: Path) -> None:
+    tar_path, expected = create_sample_dump(tmp_path)
+    records = list(iter_arxiv_records(str(tar_path)))
+    assert records == expected


### PR DESCRIPTION
## Summary
- add streaming loader for arXiv metadata dump tar.xz archives
- test loader against a synthetic dump
- fix pre-commit config's prettier version

## Testing
- `pre-commit run --files backend/app/arxiv_loader.py backend/tests/test_arxiv_loader.py .pre-commit-config.yaml`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6899181f82348321bbcaa4ad0ec9b955