### PR TITLE
Add static arXiv DOI lookup page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # ParallarXiv
 
 ## Features
+
 - FastAPI backend with Socket.IO support
 - Next.js 14 frontend using React-Three-Fiber and Rapier.js
 - Docker compose for local services (MongoDB, Qdrant)
@@ -8,17 +9,27 @@
 - GitHub Actions CI with lint, tests and build
 
 ## Tech Stack
+
 - **Backend:** Python 3.12, FastAPI, Socket.IO
 - **Frontend:** Next.js, React-Three-Fiber, Rapier.js (WASM)
 - **Infra:** Docker Compose (MongoDB, Qdrant)
 
 ## Local Dev
+
 1. Run `.codex/setup.sh` to install dependencies and run checks.
 2. `docker-compose -f infra/docker-compose.yaml up` to start services.
 3. `pnpm --prefix frontend dev` and `uvicorn app.main:app --reload --port 8000`.
 
 ## CI
+
 Automated via GitHub Actions workflow in `.github/workflows/ci.yml`.
 
+## GitHub Pages DOI Lookup
+
+The `docs/` directory hosts a minimal static site that lets you enter a DOI and
+fetch metadata from the arXiv API. Enable GitHub Pages for this repository and
+select the `docs` folder as the source to make the page available online.
+
 ## Licence
+
 MIT

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>arXiv DOI Lookup</title>
+  </head>
+  <body>
+    <h1>arXiv DOI Lookup</h1>
+    <form id="doi-form">
+      <input
+        type="text"
+        id="doi-input"
+        placeholder="Enter DOI, e.g. 10.48550/arXiv.2101.00001"
+        required
+      />
+      <button type="submit">Fetch</button>
+    </form>
+    <pre id="results"></pre>
+    <script type="module" src="script.js"></script>
+  </body>
+</html>

--- a/docs/script.js
+++ b/docs/script.js
@@ -1,0 +1,38 @@
+async function fetchArxivByDoi(doi) {
+  const query = encodeURIComponent(`doi:${doi}`);
+  const url = `https://export.arxiv.org/api/query?search_query=${query}`;
+  const response = await fetch(url);
+  if (!response.ok) {
+    throw new Error(`Request failed: ${response.status}`);
+  }
+  const text = await response.text();
+  const parser = new DOMParser();
+  const xml = parser.parseFromString(text, "application/xml");
+  const entry = xml.querySelector("entry");
+  if (!entry) {
+    return { error: "No entry found" };
+  }
+  const authors = Array.from(entry.getElementsByTagName("author")).map(
+    (a) => a.getElementsByTagName("name")[0].textContent,
+  );
+  return {
+    title: entry.querySelector("title")?.textContent.trim(),
+    summary: entry.querySelector("summary")?.textContent.trim(),
+    authors,
+    published: entry.querySelector("published")?.textContent,
+    link: entry.querySelector("id")?.textContent,
+  };
+}
+
+document.getElementById("doi-form").addEventListener("submit", async (e) => {
+  e.preventDefault();
+  const doi = document.getElementById("doi-input").value.trim();
+  const results = document.getElementById("results");
+  results.textContent = "Loading...";
+  try {
+    const data = await fetchArxivByDoi(doi);
+    results.textContent = JSON.stringify(data, null, 2);
+  } catch (err) {
+    results.textContent = err.message;
+  }
+});


### PR DESCRIPTION
## Summary
- add `docs/` with a minimal GitHub Pages site for looking up arXiv metadata by DOI
- document how to enable the page in README

## Testing
- `pre-commit run --files README.md docs/index.html docs/script.js`
- `pytest`
- `pnpm --prefix frontend exec vitest run`


------
https://chatgpt.com/codex/tasks/task_e_6899188a233483219e00008e3b7d5ea7