### PR TITLE
Use arXiv API id_list for DOI lookup

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,9 +26,11 @@ Automated via GitHub Actions workflow in `.github/workflows/ci.yml`.
 
 ## GitHub Pages DOI Lookup
 
-The `docs/` directory hosts a minimal static site that lets you enter a DOI and
-fetch metadata from the arXiv API. Enable GitHub Pages for this repository and
-select the `docs` folder as the source to make the page available online.
+The `docs/` directory hosts a minimal static site that lets you enter an
+arXiv DOI (e.g. `10.48550/arXiv.2101.00001`) and fetch metadata from the
+official arXiv API via its `id_list` parameter. Enable GitHub Pages for this
+repository and select the `docs` folder as the source to make the page
+available online.
 
 ## Licence
 

--- a/docs/script.js
+++ b/docs/script.js
@@ -1,6 +1,12 @@
 async function fetchArxivByDoi(doi) {
-  const query = encodeURIComponent(`doi:${doi}`);
-  const url = `https://export.arxiv.org/api/query?search_query=${query}`;
+  const match = doi.match(/^10\.48550\/arXiv\.(.+)$/i);
+  if (!match) {
+    return { error: "Not a valid arXiv DOI" };
+  }
+  const arxivId = match[1];
+  const url = `https://export.arxiv.org/api/query?id_list=${encodeURIComponent(
+    arxivId,
+  )}`;
   const response = await fetch(url);
   if (!response.ok) {
     throw new Error(`Request failed: ${response.status}`);


### PR DESCRIPTION
## Summary
- use arXiv API `id_list` parameter to retrieve paper metadata from DOI
- document arXiv DOI requirement for GitHub Pages lookup

## Testing
- `pre-commit run --files docs/script.js README.md`


------
https://chatgpt.com/codex/tasks/task_e_689be97568988321a03ba3bb25ceee32