### PR TITLE
feat: support flexible arxiv id input in docs lookup

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,10 +27,11 @@ Automated via GitHub Actions workflow in `.github/workflows/ci.yml`.
 ## GitHub Pages DOI Lookup
 
 The `docs/` directory hosts a minimal static site that lets you enter an
-arXiv DOI (e.g. `10.48550/arXiv.2101.00001`) and fetch metadata from the
-official arXiv API via its `id_list` parameter. Enable GitHub Pages for this
-repository and select the `docs` folder as the source to make the page
-available online.
+arXiv DOI or identifier (e.g. `10.48550/arXiv.2101.00001`,
+`arXiv:2101.00001`, or `https://doi.org/10.48550/arXiv.2101.00001`) and
+fetch metadata from the official arXiv API via its `id_list` parameter.
+Enable GitHub Pages for this repository and select the `docs` folder as the
+source to make the page available online.
 
 ## Licence
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -11,7 +11,7 @@
       <input
         type="text"
         id="doi-input"
-        placeholder="Enter DOI, e.g. 10.48550/arXiv.2101.00001"
+        placeholder="Enter DOI or arXiv ID, e.g. 10.48550/arXiv.2101.00001 or arXiv:2101.00001"
         required
       />
       <button type="submit">Fetch</button>

--- a/docs/script.js
+++ b/docs/script.js
@@ -1,9 +1,24 @@
+function extractArxivId(input) {
+  const trimmed = input.trim();
+  // Accept full DOI URLs like https://doi.org/10.48550/arXiv.1234.56789
+  let match = trimmed.match(
+    /^(?:https?:\/\/doi\.org\/)?10\.48550\/arXiv\.(.+)$/i,
+  );
+  if (match) return match[1];
+  // Accept arXiv identifiers such as arXiv:1234.56789v2
+  match = trimmed.match(/^arXiv:(.+)$/i);
+  if (match) return match[1];
+  // Finally, accept a bare arXiv id like 1234.56789v2
+  match = trimmed.match(/^[\w.-]+$/);
+  if (match) return match[0];
+  return null;
+}
+
 async function fetchArxivByDoi(doi) {
-  const match = doi.match(/^10\.48550\/arXiv\.(.+)$/i);
-  if (!match) {
+  const arxivId = extractArxivId(doi);
+  if (!arxivId) {
     return { error: "Not a valid arXiv DOI" };
   }
-  const arxivId = match[1];
   const url = `https://export.arxiv.org/api/query?id_list=${encodeURIComponent(
     arxivId,
   )}`;


### PR DESCRIPTION
## Summary
- Allow arXiv lookup page to understand DOI URLs, `arXiv:` prefixes, and bare IDs
- Clarify documentation and input placeholder about accepted arXiv DOI formats

## Testing
- `cd ParallarXiv/backend && pytest -q`
- `cd ParallarXiv/frontend && pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68a38413a07083219e0a83cdb139d669