### PR TITLE
Cache paper info and expose citation API

### DIFF
--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -1,0 +1,34 @@
+import json
+import os
+import sqlite3
+from typing import Any, Dict, Optional
+
+DB_PATH = os.environ.get("PAPER_DB_PATH", "papers.db")
+
+
+def init_db() -> None:
+    """Initialise the SQLite database and ensure the papers table exists."""
+    with sqlite3.connect(DB_PATH) as conn:
+        conn.execute(
+            "CREATE TABLE IF NOT EXISTS papers (id TEXT PRIMARY KEY, data TEXT NOT NULL)"
+        )
+
+
+def get_paper(paper_id: str) -> Optional[Dict[str, Any]]:
+    """Retrieve a cached paper by its ID."""
+    with sqlite3.connect(DB_PATH) as conn:
+        cur = conn.execute("SELECT data FROM papers WHERE id=?", (paper_id,))
+        row = cur.fetchone()
+    if row:
+        return json.loads(row[0])
+    return None
+
+
+def save_paper(paper_id: str, data: Dict[str, Any]) -> None:
+    """Store paper information in the cache."""
+    with sqlite3.connect(DB_PATH) as conn:
+        conn.execute(
+            "INSERT OR REPLACE INTO papers (id, data) VALUES (?, ?)",
+            (paper_id, json.dumps(data)),
+        )
+        conn.commit()

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,8 +1,14 @@
 from fastapi import FastAPI
 import socketio
+import httpx
+
+from .database import init_db, get_paper, save_paper
 
 sio = socketio.AsyncServer(async_mode="asgi")
 app = FastAPI()
+app.mount("/ws", socketio.ASGIApp(sio))
+
+init_db()
 
 
 @sio.event
@@ -10,9 +16,30 @@ async def connect(sid, environ):
     print(f"Socket connected: {sid}")
 
 
-app.mount("/ws", socketio.ASGIApp(sio))
-
-
 @app.get("/health")
 async def health():
     return {"status": "ok"}
+
+
+async def fetch_paper_info(paper_id: str) -> dict:
+    """Fetch paper details including references from Semantic Scholar."""
+    fields = (
+        "title,abstract,authors.name,year,referenceCount,citationCount,"
+        "references.paperId,references.title"
+    )
+    url = f"https://api.semanticscholar.org/graph/v1/paper/arXiv:{paper_id}"
+    async with httpx.AsyncClient(timeout=10) as client:
+        resp = await client.get(url, params={"fields": fields})
+        resp.raise_for_status()
+        return resp.json()
+
+
+@app.get("/paper/{paper_id}")
+async def get_paper_info(paper_id: str):
+    """Return information about a paper, caching results in a database."""
+    cached = get_paper(paper_id)
+    if cached:
+        return cached
+    data = await fetch_paper_info(paper_id)
+    save_paper(paper_id, data)
+    return data

--- a/backend/tests/test_paper_cache.py
+++ b/backend/tests/test_paper_cache.py
@@ -1,0 +1,29 @@
+import importlib
+from fastapi.testclient import TestClient
+
+from app import main, database
+
+
+def test_paper_cached(tmp_path, monkeypatch):
+    db_path = tmp_path / "papers.db"
+    monkeypatch.setenv("PAPER_DB_PATH", str(db_path))
+    importlib.reload(database)
+    importlib.reload(main)
+
+    client = TestClient(main.app)
+    calls = {"n": 0}
+
+    async def fake_fetch(paper_id: str):
+        calls["n"] += 1
+        return {"paperId": paper_id, "references": []}
+
+    monkeypatch.setattr(main, "fetch_paper_info", fake_fetch)
+
+    resp1 = client.get("/paper/abc123")
+    assert resp1.status_code == 200
+    assert resp1.json()["paperId"] == "abc123"
+    assert calls["n"] == 1
+
+    resp2 = client.get("/paper/abc123")
+    assert resp2.status_code == 200
+    assert calls["n"] == 1


### PR DESCRIPTION
## Summary
- cache paper metadata in SQLite
- fetch citation details from Semantic Scholar and cache
- add regression test for caching behaviour

## Testing
- `pre-commit run --files backend/app/database.py backend/app/main.py backend/tests/test_paper_cache.py`
- `cd backend && pytest`


------
https://chatgpt.com/codex/tasks/task_e_68aa2126290c8321895008273ad249d4