### PR TITLE
Log when serving cached paper data

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -39,6 +39,7 @@ async def get_paper_info(paper_id: str):
     """Return information about a paper, caching results in a database."""
     cached = get_paper(paper_id)
     if cached:
+        print(f"Paper {paper_id} served from database cache instead of arXiv")
         return cached
     data = await fetch_paper_info(paper_id)
     save_paper(paper_id, data)


### PR DESCRIPTION
## Summary
- log when a requested paper is served from the database cache instead of fetched from arXiv

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68aa23ef20948321bd9161303cb36058