### PR TITLE
Switch static site deployment to Vercel

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,14 +24,16 @@
 
 Automated via GitHub Actions workflow in `.github/workflows/ci.yml`.
 
-## GitHub Pages DOI Lookup
+## Vercel DOI Lookup
 
 The `docs/` directory hosts a minimal static site that lets you enter an
 arXiv DOI or identifier (e.g. `10.48550/arXiv.2101.00001`,
 `arXiv:2101.00001`, or `https://doi.org/10.48550/arXiv.2101.00001`) and
 fetch metadata from the official arXiv API via its `id_list` parameter.
-Enable GitHub Pages for this repository and select the `docs` folder as the
-source to make the page available online.
+
+To publish this site, connect the repository to [Vercel](https://vercel.com)
+and deploy. The included `vercel.json` routes the project so the `docs/`
+folder is served from the root URL, eliminating the need for GitHub Pages.
 
 ## Licence
 

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,4 @@
+{
+  "builds": [{ "src": "docs/**", "use": "@vercel/static" }],
+  "routes": [{ "src": "/(.*)", "dest": "docs/$1" }]
+}


### PR DESCRIPTION
## Summary
- add `vercel.json` to serve `docs` folder on Vercel
- update README to describe Vercel deployment instead of GitHub Pages

## Testing
- `pre-commit run --files README.md vercel.json`

------
https://chatgpt.com/codex/tasks/task_e_68ab5b1ac43c83219956fb5a7df68f9f